### PR TITLE
A translation issue has been fixed.

### DIFF
--- a/devtools/client/netmonitor.properties
+++ b/devtools/client/netmonitor.properties
@@ -216,7 +216,7 @@ networkMenu.summary.transferred=%S / %S передано
 
 # LOCALIZATION NOTE (networkMenu.summary.tooltip.transferred): A tooltip explaining
 # what the transferred label displays
-networkMenu.summary.tooltip.transferred=Передано/размер всех запросов
+networkMenu.summary.tooltip.transferred=Размер/передано всех запросов
 
 # LOCALIZATION NOTE (networkMenu.summary.finish): This label is displayed
 # in the network table footer providing the transfer time.


### PR DESCRIPTION
In the app "n MB / n MB передано" is shown, but a pop-up tip says "Передано/размер всех запросов". The correct variant would be "Размер/передано всех запросов".
Translated by Marina. Thx.